### PR TITLE
chore: add .github/dependabot.yml to ignore gomod in test/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/test"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
This repo is in deep maintenance mode and receives a lot of dependabot alerts in the testsuite. As the testsuite will only ever work with trusted input, we've been ignoring them, which creates busy work. Instead, just ignore the test/ directory.